### PR TITLE
Add GoGoSense Compatibility

### DIFF
--- a/src/GoGoController.java
+++ b/src/GoGoController.java
@@ -7,7 +7,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.ArrayList;
 
-// Use the full replacement RXTX which has it's own package space
+// Use the full replacement RXTX which has its own package space
 // and doesn't need to Sun javax.comm jar
 import gnu.io.*;
 
@@ -23,9 +23,6 @@ public class GoGoController {
 
   // current burst mode
   public int burstModeMask = 0;
-  
-  //Text to be passed to gogo:debug
-  public String debugText;
 
   public static final byte IN_HEADER1 = (byte) 0x55;
   public static final byte IN_HEADER2 = (byte) 0xFF;
@@ -113,7 +110,6 @@ public class GoGoController {
 
 
   public GoGoController(String portName) {
-	debugText="";
     this.portName = portName;
   }
 
@@ -298,10 +294,8 @@ public class GoGoController {
       for (int i = 0; i < 256; i++) {
         synchronized (inputStream) {
           b = readByte();
-		  debugText+="RH1_"+Integer.toHexString((int)b&0xFF)+"   ";
           if (b == IN_HEADER1) {
             b = readByte();
-			debugText+="RH2_"+Integer.toHexString((int)b&0xFF)+"   ";
             if (b == IN_HEADER2) return true;
           }
         }
@@ -309,7 +303,6 @@ public class GoGoController {
     } catch (IOException e) {
       e.printStackTrace();
     }
-	debugText+="waitForReplyHeader failed.";
     return false;
   }
 
@@ -319,7 +312,6 @@ public class GoGoController {
       for (int i = 0; i < 256; i++) {
         synchronized (inputStream) {
           b = readByte();
-		  debugText+="WB_"+Integer.toHexString((int)b&0xFF)+"   ";
           if (b == target) {
             return true;
           }
@@ -328,7 +320,6 @@ public class GoGoController {
     } catch (IOException e) {
       e.printStackTrace();
     }
-	debugText+="waitForByte failed.";
     return false;
   }
 
@@ -401,22 +392,22 @@ public class GoGoController {
   //Reads a sensor from the independent GoGoSense board.
   public int readModSensor(int sensor) {
     int sensorVal = 0;
-	
-	//Break sensor value into bytes to send to board
-	byte highByte = (byte)(sensor>>8);
-	byte lowByte = (byte)(sensor&0xFF);
-	
-	//Create command string
-	byte[] command = {CMD_READ_MOD_SENSOR, highByte, lowByte};
-	
-	//Send command
-	try {
-	  writeCommand(command);
-	  synchronized (inputStream) { //Seize input stream to prevent simultaneous reads
-	    waitForReplyHeader();
-		sensorVal = readInt() << 8;
-		sensorVal += readInt();
-	  }
+    
+    //Break sensor value into bytes to send to board
+    byte highByte = (byte) (sensor >> 8);
+    byte lowByte = (byte) (sensor & 0xFF);
+    
+    //Create command string
+    byte[] command = {CMD_READ_MOD_SENSOR, highByte, lowByte};
+    
+    //Send command
+    try {
+      writeCommand(command);
+      synchronized (inputStream) { //Seize input stream to prevent simultaneous reads
+        waitForReplyHeader();
+        sensorVal = readInt() << 8;
+        sensorVal += readInt();
+      }
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -579,12 +570,6 @@ public class GoGoController {
   
   
   
-  //Debug code: sends 2 header bytes and one command byte specified as an integer
-  public void send(int command) {
-    writeCommand(new byte[]{(byte)command});
-	waitForByte((byte)0xAF); //Kludgy way to send reply to debugText
-  }
-
 
   // main for GoGoController class, which functions as a small utility
 

--- a/src/GoGoController.java
+++ b/src/GoGoController.java
@@ -340,7 +340,7 @@ public class GoGoController {
     if (port == null) {
       return false;
     }
-    writeCommand(new byte[]{CMD_PING});
+    writeCommand(new byte[]{ CMD_PING });
     return waitForAck();
   }
 
@@ -348,7 +348,7 @@ public class GoGoController {
     if (port == null) {
       return false;
     }
-    writeCommand(new byte[]{CMD_BEEP, (byte) 0x00});
+    writeCommand(new byte[]{ CMD_BEEP, (byte) 0x00 });
     return waitForAck();
   }
 
@@ -361,7 +361,7 @@ public class GoGoController {
     int b = CMD_READ_SENSOR | ((sensor - 1) << 2) | mode;
 
     try {
-      writeCommand(new byte[]{(byte) b});
+      writeCommand(new byte[]{ (byte) b });
       synchronized (inputStream) {
         waitForReplyHeader();
         sensorVal = readInt() << 8;
@@ -398,7 +398,7 @@ public class GoGoController {
     byte lowByte = (byte) (sensor & 0xFF);
     
     //Create command string
-    byte[] command = {CMD_READ_MOD_SENSOR, highByte, lowByte};
+    byte[] command = { CMD_READ_MOD_SENSOR, highByte, lowByte };
     
     //Send command
     try {
@@ -418,8 +418,8 @@ public class GoGoController {
 
 
   public void talkToOutputPorts(int outputPortMask) {
-    writeCommand(new byte[]{CMD_TALK_TO_OUTPUT_PORT,
-        (byte) outputPortMask});
+    writeCommand(new byte[]{ CMD_TALK_TO_OUTPUT_PORT,
+        (byte) outputPortMask });
     waitForAck();
   }
 
@@ -429,8 +429,8 @@ public class GoGoController {
   }
 
   public void setBurstMode(int sensorMask, int speed) {
-    writeCommand(new byte[]{((byte) (CMD_SET_BURST_MODE | (byte) speed)),
-        (byte) sensorMask});
+    writeCommand(new byte[]{ ((byte) (CMD_SET_BURST_MODE | (byte) speed)),
+        (byte) sensorMask} );
     waitForAck();
     burstModeMask = sensorMask;
   }
@@ -484,7 +484,7 @@ public class GoGoController {
   }
 
   public void outputPortControl(byte cmd) {
-    writeCommand(new byte[]{cmd});
+    writeCommand(new byte[]{ cmd });
     waitForAck();
   }
 
@@ -519,7 +519,7 @@ public class GoGoController {
 
     int comm = CMD_OUTPUT_PORT_POWER | level << 2;
 
-    writeCommand(new byte[]{(byte) comm});
+    writeCommand(new byte[]{ (byte) comm });
 
     waitForAck();
   }

--- a/src/GoGoController.java
+++ b/src/GoGoController.java
@@ -32,7 +32,7 @@ public class GoGoController {
 
   public static final byte CMD_PING = (byte) 0x00;
   public static final byte CMD_READ_SENSOR = (byte) 0x20;
-  public static final byte CMD_READ_MOD_SENSOR = (byte) 0xE0;
+  public static final byte CMD_READ_EXTENDED_SENSOR = (byte) 0xE0;
   public static final byte CMD_OUTPUT_PORT_ON = (byte) 0x40;
   public static final byte CMD_OUTPUT_PORT_OFF = (byte) 0x44;
   public static final byte CMD_OUTPUT_PORT_RD = (byte) 0x48;
@@ -355,8 +355,10 @@ public class GoGoController {
   public int _readSensor(int sensor, int mode) {
     int sensorVal = 0;
 
-    if ((sensor < 1) || (sensor > 8))
+    if (sensor < 1)
       throw new RuntimeException("Sensor number out of range: " + sensor);
+    if (sensor > 8)
+      return readExtendedSensor(sensor);
 
     int b = CMD_READ_SENSOR | ((sensor - 1) << 2) | mode;
 
@@ -389,16 +391,20 @@ public class GoGoController {
   }
 
   
-  //Reads a sensor from the independent GoGoSense board.
-  public int readModSensor(int sensor) {
+  //Reads a sensor with number >8.
+  //Such sensors use a different serial format.
+  public int readExtendedSensor(int sensor) {
     int sensorVal = 0;
+    
+    //Turn sensor number (9+) into 0+
+    sensor=sensor-9;
     
     //Break sensor value into bytes to send to board
     byte highByte = (byte) (sensor >> 8);
     byte lowByte = (byte) (sensor & 0xFF);
     
     //Create command string
-    byte[] command = { CMD_READ_MOD_SENSOR, highByte, lowByte };
+    byte[] command = { CMD_READ_EXTENDED_SENSOR, highByte, lowByte };
     
     //Send command
     try {

--- a/src/GoGoController.java
+++ b/src/GoGoController.java
@@ -397,7 +397,7 @@ public class GoGoController {
     int sensorVal = 0;
     
     //Turn sensor number (9+) into 0+
-    sensor=sensor-9;
+    sensor = sensor - 9;
     
     //Break sensor value into bytes to send to board
     byte highByte = (byte) (sensor >> 8);

--- a/src/GoGoExtension.java
+++ b/src/GoGoExtension.java
@@ -38,12 +38,8 @@ public class GoGoExtension extends org.nlogo.api.DefaultClassManager {
     primManager.addPrimitive("stop-burst-mode", new GoGoStopBurstMode());
     primManager.addPrimitive("burst-value", new GoGoSensorBurstValue());
     primManager.addPrimitive("sensor", new GoGoSensor());
-	primManager.addPrimitive("msensor", new ModSensor());
-	
-	//Debug code
-    primManager.addPrimitive("send", new GoGoSendByte());
-    primManager.addPrimitive("debug", new GoGoDebug());
-    primManager.addPrimitive("clear", new GoGoDebugClear());
+    primManager.addPrimitive("msensor", new ModSensor());
+    
     //primManager.addPrimitive( "switch", new GoGoSwitch() ) ;
   }
 
@@ -126,13 +122,8 @@ public class GoGoExtension extends org.nlogo.api.DefaultClassManager {
       }
 
       try {
-		controller.writeCommand(new byte[]{(byte)0x00});
-		if (!controller.waitForReplyHeader()) {
-          throw new ExtensionException("GoGo board not responding: No reply header.");
-        }
-        if (!controller.waitForByte((byte)0xAA)) {
-          throw new ExtensionException("GoGo board not responding: No ack byte.");
-        }
+        if (!controller.ping()) {
+          throw new ExtensionException("GoGo board not responding.");
       } catch (RuntimeException e) {
         throw new ExtensionException("GoGo board not responding: " + e.getLocalizedMessage());
       }
@@ -476,42 +467,6 @@ public class GoGoExtension extends org.nlogo.api.DefaultClassManager {
     }
   }
 
-  
-  
-  
-  //Debugging code
-  //Shows the debug text from the GoGo Controller.
-  public static class GoGoDebug extends DefaultReporter {
-    public Object report(Argument args[], Context context)
-        throws ExtensionException, org.nlogo.api.LogoException {
-	  if (controller.debugText==null)
-		return "NULL";
-      return controller.debugText;
-    }
-  }
-
-  //Clears the debug text
-  public static class GoGoDebugClear extends DefaultCommand {
-    public void perform(Argument args[], Context context)
-        throws ExtensionException, org.nlogo.api.LogoException {
-      controller.debugText=""; //clear text
-    }
-  }
-  
-  //Sends two header bytes and a command byte to the GoGo Board.
-  public static class GoGoSendByte extends DefaultCommand {
-    public Syntax getSyntax() {
-	  //Takes a single argument (the command byte) to the right
-	  //e.g. gogo:send 20
-      int[] right = {Syntax.NumberType()};
-      return Syntax.commandSyntax(right);
-    }
-	
-    public void perform(Argument args[], Context context)
-        throws ExtensionException, org.nlogo.api.LogoException {
-      controller.send(args[0].getIntValue()); //Send integer
-    }
-  }
 
   @Override
   public java.util.List<String> additionalJars() {

--- a/src/GoGoExtension.java
+++ b/src/GoGoExtension.java
@@ -38,8 +38,6 @@ public class GoGoExtension extends org.nlogo.api.DefaultClassManager {
     primManager.addPrimitive("stop-burst-mode", new GoGoStopBurstMode());
     primManager.addPrimitive("burst-value", new GoGoSensorBurstValue());
     primManager.addPrimitive("sensor", new GoGoSensor());
-    primManager.addPrimitive("msensor", new ModSensor());
-    
     //primManager.addPrimitive( "switch", new GoGoSwitch() ) ;
   }
 
@@ -448,25 +446,6 @@ public class GoGoExtension extends org.nlogo.api.DefaultClassManager {
     }
   }
   
-  //A sensor on the GoGo Sense independent board
-  public static class ModSensor extends DefaultReporter {
-    public Syntax getSyntax() {
-      int[] right = {Syntax.NumberType()}; //This primitive takes one number to its right, e.g. msensor 372
-      return Syntax.reporterSyntax(right, Syntax.NumberType()); //And returns a NumberType as well - the sensor value.
-    }
-
-    public Object report(Argument args[], Context context)
-        throws ExtensionException, org.nlogo.api.LogoException {
-
-      int sensor = args[0].getIntValue(); //Get the sensor number passed in
-      try {
-        return Double.valueOf(controller.readModSensor(sensor));
-      } catch (RuntimeException e) {
-        return Double.valueOf(0); //If can't read the sensor value, return 0.
-      }
-    }
-  }
-
 
   @Override
   public java.util.List<String> additionalJars() {

--- a/src/GoGoExtension.java
+++ b/src/GoGoExtension.java
@@ -122,6 +122,7 @@ public class GoGoExtension extends org.nlogo.api.DefaultClassManager {
       try {
         if (!controller.ping()) {
           throw new ExtensionException("GoGo board not responding.");
+        }
       } catch (RuntimeException e) {
         throw new ExtensionException("GoGo board not responding: " + e.getLocalizedMessage());
       }


### PR DESCRIPTION
The GoGoSense project is a project to expand the capabilities of the GoGo Board. This commit adds a command to NetLogo called "msensor." This requests an extended sensor value from the GoGo Board or independent GoGoSense board (which can connect to NetLogo directly, or connect to the GoGo Board). 

The sensor request is sent in the form [out header] 0b11100000 [sensor number high byte] [low byte]. 0b11100000 does not collide with any of the commands listed in the GoGo Board serial protocol. The connected board responds with [in header] [sensor value high byte] [low byte], in the same way as it would reply to a normal sensor request.

This commit does not yet support burst mode for the extended sensor bank.

This commit also contains debug code. Each instance of GoGoController has a public String, debugText. Various methods append output to this string: specifically, when a method is waiting for input from the GoGo Board, it writes "[description of expected input]_[received input as hex string]    ." For example, when waiting for the first reply header, "RH1_0xFF     " could be appended to the string. Users can access the string with the command gogo:debug, and clear it with gogo:clear.
